### PR TITLE
Reduce maximal size of copied data to not overflow buffer

### DIFF
--- a/leds-f4-220.c
+++ b/leds-f4-220.c
@@ -72,7 +72,7 @@ static ssize_t leds_write(struct file *file, const char __user *buf,
 {
 #define BUFSIZE 64
 	char buffer[BUFSIZE];
-	count = min(count, sizeof(buffer));
+	count = min(count, sizeof(buffer)-1);
 	if (copy_from_user(&buffer, buf, count))
 		return -EFAULT;
 	buffer[count] = 0;


### PR DESCRIPTION
When `count` is `sizeof(buffer)`, `buffer[count] = 0` writes one past the end of the buffer.

By limiting `count` to `sizeof(buffer)-1` everything stays safely in bounds.