### PR TITLE
Add `dkms` as a build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: led-drv-f4-220
 Section: universe/utils
 Priority: optional
 Maintainer: Mike Stroyan <mike@stroyan.net>
-Build-Depends: debhelper-compat (= 12)
+Build-Depends: debhelper-compat (= 12), dkms
 Standards-Version: 4.4.0
 Homepage: https://github.com/stroyan/led-drv-f4-220
 Vcs-Browser: https://github.com/stroyan/led-drv-f4-220.git


### PR DESCRIPTION
`dkms` is required to build the package (it contains the `dkms.pm` debhelper module).